### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/DATA_PREP.md
+++ b/DATA_PREP.md
@@ -22,7 +22,7 @@ $ shp2pgsql -I -s 4326 cook_county_parcels.shp parcels | psql -U <db_user> -d <d
 $ shp2pgsql -I -s 4326 chicago_addresses.shp chicago_addresses | psql -U postgres -d wopr
 ```
 
-**Load Land Inventory using ``csvsql`` (from [csvkit](http://csvkit.readthedocs.org/))**
+**Load Land Inventory using ``csvsql`` (from [csvkit](https://csvkit.readthedocs.io/))**
 
 ```bash
 $ cat land_inventory.csv | \


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.