### PR TITLE
Refactor python manage.py send_emails --eds_email=n to select and email n applicants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .env
 /static
 local_settings.py
+.cache

--- a/lots_admin/management/commands/send_emails.py
+++ b/lots_admin/management/commands/send_emails.py
@@ -101,14 +101,16 @@ class Command(BaseCommand):
 
                 # Set `eds_sent` = True on all applications for given applicant
                 # (since we only need one EDS per applicant)
-                all_applications = Application.objects.filter(email=email_address)
+                active_applications = ApplicationStatus.objects\
+                                                       .filter(application__email=email_address)\
+                                                       .filter(denied=False)
 
                 print('Updated applications for {}:'.format(applicant))
-                for application in all_applications:
-                    print(self.applicant_detail_str(application))
-                    application.eds_sent = True
-                    application.save()
-
+                for app in active_applications:
+                    print(self.applicant_detail_str(app.application))
+                    app.application.eds_sent = True
+                    app.application.save()
+                    
 
         if options['deed_upload']:
             applications = Application.objects.all()

--- a/lots_admin/management/commands/send_emails.py
+++ b/lots_admin/management/commands/send_emails.py
@@ -65,12 +65,11 @@ class Command(BaseCommand):
 
                 print('Notified {}'.format(applicant))
 
-                # Find all EDS-ready applications for for given applicant 
-                # and set `eds_sent` = True
+                # Set `eds_sent` = True on all applications for given applicant
+                # (since we only need one EDS per applicant)
 
                 all_applications = Application.objects\
-                                              .filter(email=app.application.email)\
-                                              .filter(applicationstatus__current_step__step=7)
+                                              .filter(email=app.application.email)
 
                 print('Updated applications for {}:'.format(applicant))
                 

--- a/lots_admin/management/commands/send_emails.py
+++ b/lots_admin/management/commands/send_emails.py
@@ -70,9 +70,9 @@ class Command(BaseCommand):
                         denied
                       FROM lots_admin_application AS app
                       JOIN lots_admin_applicationstatus AS status
-                      ON app.id=status.application_id
+                      ON app.id = status.application_id
                       JOIN lots_admin_applicationstep AS step
-                      ON status.current_step_id=step.id
+                      ON status.current_step_id = step.id
                       WHERE eds_sent = False 
                         AND denied = False
                     ) AS applicants

--- a/lots_admin/tests/conftest.py
+++ b/lots_admin/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+
+from django.core.management import call_command
+
+@pytest.fixture(scope='session')
+def django_db_setup(django_db_setup, django_db_blocker):
+    '''Insert the following into the test_largelots database:
+
+    * Two addresses
+      * 1 - 4539 N Paulina
+      * 2 - 440 S LaSalle
+
+    * Two lots
+      * 13131 - corresponds to address 1
+      * 34343 - corresponds to address 2
+
+    * Two application steps
+      * 1 - Step 6: Alderman letter
+      * 2 - Step 7: EDS needed
+
+    * Three applications
+      * 1 - Rivers Cuomo
+      * 2 - Robin Peckinold
+      * 3 - Lana Del Rey
+
+    * Three application statuses
+      * 1 - Rivers Cuomo, EDS needed, not sent (13131)
+      * 2 - Rivers Cuomo, EDS needed, not sent (34343)
+      * 3 - Robin Peckinold, Alderman letter (34343)
+      * 4 - Lana Del Rey, EDS needed and sent (34343)
+    '''
+    with django_db_blocker.unblock():
+        call_command('loaddata', 'tests/test_data.json')

--- a/lots_admin/tests/conftest.py
+++ b/lots_admin/tests/conftest.py
@@ -4,30 +4,17 @@ from django.core.management import call_command
 
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):
-    '''Insert the following into the test_largelots database:
+    '''Insert test_data.json into the `test_largelots` database,
+    resulting in the following field of applicants: 
 
-    * Two addresses
-      * 1 - 4539 N Paulina
-      * 2 - 440 S LaSalle
-
-    * Two lots
-      * 13131 - corresponds to address 1
-      * 34343 - corresponds to address 2
-
-    * Two application steps
-      * 1 - Step 6: Alderman letter
-      * 2 - Step 7: EDS needed
-
-    * Three applications
-      * 1 - Rivers Cuomo
-      * 2 - Robin Peckinold
-      * 3 - Lana Del Rey
-
-    * Three application statuses
-      * 1 - Rivers Cuomo, EDS needed, not sent (13131)
-      * 2 - Rivers Cuomo, EDS needed, not sent (34343)
-      * 3 - Robin Peckinold, Alderman letter (34343)
-      * 4 - Lana Del Rey, EDS needed and sent (34343)
+     first_name | last_name |            email            | eds_sent | step | denied
+    ------------+-----------+-----------------------------+----------+------+--------
+     Rivers     | Cuomo     | weezerules@yahoo.com        | f        |    7 | f
+     Rivers     | Cuomo     | weezerules@yahoo.com        | f        |    7 | f
+     Robin      | Peckinold | fleetfoxesfanclub@yahoo.com | f        |    6 | f
+     Lana       | Del Rey   | natlanthemmm@gmail.com      | t        |    7 | f
+     Karen      | Oh        | goldlion@hotmail.com        | f        |    6 | t
+     Karen      | Oh        | goldlion@hotmail.com        | f        |    7 | f
     '''
     with django_db_blocker.unblock():
         call_command('loaddata', 'lots_admin/tests/test_data.json')

--- a/lots_admin/tests/conftest.py
+++ b/lots_admin/tests/conftest.py
@@ -30,4 +30,4 @@ def django_db_setup(django_db_setup, django_db_blocker):
       * 4 - Lana Del Rey, EDS needed and sent (34343)
     '''
     with django_db_blocker.unblock():
-        call_command('loaddata', 'tests/test_data.json')
+        call_command('loaddata', 'lots_admin/tests/test_data.json')

--- a/lots_admin/tests/test_config.py
+++ b/lots_admin/tests/test_config.py
@@ -1,0 +1,24 @@
+SECRET_KEY = 'running man was a good movie'
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'lots_client',
+    'lots_admin',
+    'bootstrap_pagination',
+)
+
+DATABASES = {
+   'default': {
+       'ENGINE': 'django.db.backends.postgresql',
+       'NAME': 'largelots',
+       'USER': '',
+       'PASSWORD': '',
+       'HOST': 'localhost',
+       'PORT': '5432',
+   }
+}

--- a/lots_admin/tests/test_data.json
+++ b/lots_admin/tests/test_data.json
@@ -1,0 +1,198 @@
+[
+    {
+        "model": "lots_admin.address",
+        "pk": 1,
+        "fields": {
+            "street": "4539 N Paulina",
+            "street_number": null,
+            "street_dir": null,
+            "street_name": null,
+            "street_type": null,
+            "city": "Chicago",
+            "state": "IL",
+            "zip_code": "60640",
+            "ward": null,
+            "community": null
+        }
+    },
+    {
+        "model": "lots_admin.address",
+        "pk": 2,
+        "fields": {
+            "street": "440 S LaSalle",
+            "street_number": null,
+            "street_dir": null,
+            "street_name": null,
+            "street_type": null,
+            "city": "Chicago",
+            "state": "IL",
+            "zip_code": null,
+            "ward": null,
+            "community": null
+        }
+    },
+    {
+        "model": "lots_admin.application",
+        "pk": 1,
+        "fields": {
+            "first_name": "Rivers",
+            "last_name": "Cuomo",
+            "organization": "",
+            "owned_pin": "45678",
+            "owned_address": 1,
+            "deed_image": "img/cool-deed-1.png",
+            "deed_timestamp": null,
+            "contact_address": 1,
+            "phone": "312-675-3463",
+            "email": "weezerules@yahoo.com",
+            "how_heard": "really big headphones",
+            "tracking_id": "db92f88c-64f8-4cbf-95fe-2420c36c13a3",
+            "received_date": "2017-07-17T14:34:23.075",
+            "pilot": "3",
+            "eds_sent": false
+        }
+    },
+    {
+        "model": "lots_admin.application",
+        "pk": 2,
+        "fields": {
+            "first_name": "Rivers",
+            "last_name": "Cuomo",
+            "organization": "",
+            "owned_pin": "45678",
+            "owned_address": 1,
+            "deed_image": "img/cool-deed-1.png",
+            "deed_timestamp": null,
+            "contact_address": 1,
+            "phone": "312-675-3463",
+            "email": "weezerules@yahoo.com",
+            "how_heard": "really big headphones",
+            "tracking_id": "db92f88c-64f8-4cbf-95fe-2420c36c13a3",
+            "received_date": "2017-07-17T14:34:23.075",
+            "pilot": "3",
+            "eds_sent": false
+        }
+    },
+    {
+        "model": "lots_admin.application",
+        "pk": 3,
+        "fields": {
+            "first_name": "Robin",
+            "last_name": "Peckinold",
+            "organization": "",
+            "owned_pin": "12345",
+            "owned_address": 2,
+            "deed_image": "img/montezuma.png",
+            "deed_timestamp": null,
+            "contact_address": 2,
+            "phone": "302-123-4567",
+            "email": "fleetfoxesfanclub@yahoo.com",
+            "how_heard": "pitchfork dot com",
+            "tracking_id": "fc8be17e-9f58-4f4c-b403-caa3cfb2b995",
+            "received_date": "2017-06-17T15:14:31.705",
+            "pilot": "3",
+            "eds_sent": false
+        }
+    },
+    {
+        "model": "lots_admin.application",
+        "pk": 4,
+        "fields": {
+            "first_name": "Lana",
+            "last_name": "Del Rey",
+            "organization": "",
+            "owned_pin": "09876",
+            "owned_address": 1,
+            "deed_image": "img/kiss-kiss.png",
+            "deed_timestamp": null,
+            "contact_address": 1,
+            "phone": "987-324-8792",
+            "email": "natlanthemmm@gmail.com",
+            "how_heard": "bulletin board",
+            "tracking_id": "7370eab5-4e16-4648-89e3-f2cfcf139ac5",
+            "received_date": "2017-07-17T14:34:23.075",
+            "pilot": "3",
+            "eds_sent": true
+        }
+    },
+    {
+        "model": "lots_admin.lot",
+        "pk": "34343",
+        "fields": {
+            "address": 2,
+            "planned_use": null,
+            "application": []
+        }
+    },
+    {
+        "model": "lots_admin.lot",
+        "pk": "13131",
+        "fields": {
+            "address": 1,
+            "planned_use": null,
+            "application": []
+        }
+    },
+    {
+        "model": "lots_admin.applicationstep",
+        "pk": 1,
+        "fields": {
+            "description": "Alderman letter of support",
+            "public_status": "valid",
+            "step": 6
+        }
+    },
+    {
+        "model": "lots_admin.applicationstep",
+        "pk": 2,
+        "fields": {
+            "description": "Wait for applicant to submit EDS and principal profile",
+            "public_status": "valid",
+            "step": 7
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 1,
+        "fields": {
+            "denied": false,
+            "application": 1,
+            "lot": "34343",
+            "current_step": 2,
+            "lottery": false
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 2,
+        "fields": {
+            "denied": false,
+            "application": 2,
+            "lot": "13131",
+            "current_step": 2,
+            "lottery": false
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 3,
+        "fields": {
+            "denied": false,
+            "application": 3,
+            "lot": "34343",
+            "current_step": 1,
+            "lottery": false
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 4,
+        "fields": {
+            "denied": false,
+            "application": 4,
+            "lot": "34343",
+            "current_step": 2,
+            "lottery": false
+        }
+    }
+]

--- a/lots_admin/tests/test_data.json
+++ b/lots_admin/tests/test_data.json
@@ -116,6 +116,48 @@
         }
     },
     {
+        "model": "lots_admin.application",
+        "pk": 5,
+        "fields": {
+            "first_name": "Karen",
+            "last_name": "Oh",
+            "organization": "",
+            "owned_pin": "12345",
+            "owned_address": 2,
+            "deed_image": "img/yayaya.png",
+            "deed_timestamp": null,
+            "contact_address": 2,
+            "phone": "302-123-4567",
+            "email": "goldlion@hotmail.com",
+            "how_heard": "the year 2004",
+            "tracking_id": "cffd359c-af8b-4286-8ac9-9a33748a9f9c",
+            "received_date": "2017-06-17T15:14:31.705",
+            "pilot": "3",
+            "eds_sent": false
+        }
+    },
+    {
+        "model": "lots_admin.application",
+        "pk": 6,
+        "fields": {
+            "first_name": "Karen",
+            "last_name": "Oh",
+            "organization": "",
+            "owned_pin": "12345",
+            "owned_address": 2,
+            "deed_image": "img/yayaya.png",
+            "deed_timestamp": null,
+            "contact_address": 2,
+            "phone": "302-123-4567",
+            "email": "goldlion@hotmail.com",
+            "how_heard": "the year 2004",
+            "tracking_id": "09328127-fa9a-4979-a0bc-09734c91737c",
+            "received_date": "2017-06-17T15:14:31.705",
+            "pilot": "3",
+            "eds_sent": false
+        }
+    },
+    {
         "model": "lots_admin.lot",
         "pk": "34343",
         "fields": {
@@ -191,6 +233,28 @@
             "denied": false,
             "application": 4,
             "lot": "34343",
+            "current_step": 2,
+            "lottery": false
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 5,
+        "fields": {
+            "denied": true,
+            "application": 5,
+            "lot": "34343",
+            "current_step": 1,
+            "lottery": false
+        }
+    },
+    {
+        "model": "lots_admin.applicationstatus",
+        "pk": 6,
+        "fields": {
+            "denied": false,
+            "application": 6,
+            "lot": "13131",
             "current_step": 2,
             "lottery": false
         }

--- a/lots_admin/tests/test_emails.py
+++ b/lots_admin/tests/test_emails.py
@@ -1,0 +1,34 @@
+import pytest
+
+from lots_admin.models import Application, ApplicationStatus
+
+@pytest.mark.django_db
+def test_eds_email(django_db_setup):
+    '''The test database contains four application statuses,
+    two for Rivers Cuomo on step 7 with no EDS sent, one
+    for Robin Peckinold on step 6, and one for Lana Del Rey
+    on step 7 with EDS already sent.
+
+    Test that we appropriately select Rivers Cuomo once, and
+    correctly identify the related application.
+    '''
+
+    applicants = ApplicationStatus.objects\
+                                  .filter(current_step__step=7)\
+                                  .filter(application__eds_sent=False)\
+                                  .distinct('application__email')
+
+    assert len(applicants) == 1
+
+    application = applicants[0].application
+    applicant_name = ' '.join([application.first_name,
+                               application.last_name])
+
+    assert applicant_name == 'Rivers Cuomo'
+
+    related_applications = Application.objects\
+                                      .filter(email=application.email)\
+                                      .filter(applicationstatus__current_step__step=7)\
+                                      .exclude(id=application.id)
+
+    assert len(related_applications) == 1

--- a/lots_admin/tests/test_emails.py
+++ b/lots_admin/tests/test_emails.py
@@ -8,43 +8,32 @@ from lots_admin.models import Application, ApplicationStatus
 from lots_admin.management.commands.send_emails import Command
 
 @pytest.mark.django_db
-def test_eds_email(django_db_setup, capsys):
-    '''The test database contains four application statuses,
-    two for Rivers Cuomo on step 7 with no EDS sent, one
-    for Robin Peckinold on step 6, and one for Lana Del Rey
-    on step 7 with EDS already sent.
+def test_eds_email(django_db_setup):
+    '''The test database contains six application statuses
+    for four applicants:
+
+    * Two applications for Rivers Cuomo, both on step 7,
+      eds_sent = False
+    * One application for Robin Peckinold on step 6
+    * One application for Lana Del Rey on step 7, 
+      eds_sent = True
+    * Two applications for Karen Oh, one denied on step 7
+      and one active on step 7, eds_sent = False
 
     Test that we appropriately select and notify Rivers Cuomo
-    once, and update all his applications in the database.
-
-    Expect out text from `send_emails` call is:
-
-    Notified Rivers Cuomo - Application ID 1
-    Updated applications for Rivers Cuomo - Application ID 1:
-    Rivers Cuomo - Application ID 1
-    Rivers Cuomo - Application ID 2
+    and Karen Oh, and update their active applications in the 
+    database.
     '''
 
     with patch.object(Command, 'send_email') as mock_send:
         call_command('send_emails', eds_email=5, stdout=sys.stdout)
-        out, err = capsys.readouterr()
 
-    notification_message = 'Notified Rivers Cuomo - Application ID 1'
+    eds_sent_applications = Application.objects.filter(eds_sent=True)
     
-    applications = ['Rivers Cuomo - Application ID {}'.format(i) for i in (1, 2)]
-    applications_message = '\n'.join(applications)
-
-    for message in (notification_message, applications_message):
-        assert message in out
-
-    for applicant in ('Lana Del Rey', 'Robin Peckinold'):
-        assert applicant not in out
-
-    updated_applications = Application.objects.filter(first_name='Rivers', 
-                                                      last_name='Cuomo')
-
-    assert len(updated_applications) == 2
-
-    for application in updated_applications:
-        assert application.eds_sent == True
+    # We started with one application where the EDS had been sent.
+    # With the addition of two for Rivers and one for Karen, we
+    # should see four applications where `eds_sent` = True.
+    assert len(eds_sent_applications) == 4
+    assert len(eds_sent_applications.filter(first_name='Rivers')) == 2
+    assert len(eds_sent_applications.filter(first_name='Karen')) == 1
 

--- a/lots_admin/tests/test_emails.py
+++ b/lots_admin/tests/test_emails.py
@@ -43,6 +43,8 @@ def test_eds_email(django_db_setup, capsys):
     updated_applications = Application.objects.filter(first_name='Rivers', 
                                                       last_name='Cuomo')
 
+    assert len(updated_applications) == 2
+
     for application in updated_applications:
         assert application.eds_sent == True
-        
+

--- a/lots_admin/tests/test_emails.py
+++ b/lots_admin/tests/test_emails.py
@@ -1,34 +1,48 @@
 import pytest
+from unittest.mock import patch
+import sys
+
+from django.core.management import call_command
 
 from lots_admin.models import Application, ApplicationStatus
+from lots_admin.management.commands.send_emails import Command
 
 @pytest.mark.django_db
-def test_eds_email(django_db_setup):
+def test_eds_email(django_db_setup, capsys):
     '''The test database contains four application statuses,
     two for Rivers Cuomo on step 7 with no EDS sent, one
     for Robin Peckinold on step 6, and one for Lana Del Rey
     on step 7 with EDS already sent.
 
-    Test that we appropriately select Rivers Cuomo once, and
-    correctly identify the related application.
+    Test that we appropriately select and notify Rivers Cuomo
+    once, and update all his applications in the database.
+
+    Expect out text from `send_emails` call is:
+
+    Notified Rivers Cuomo - Application ID 1
+    Updated applications for Rivers Cuomo - Application ID 1:
+    Rivers Cuomo - Application ID 1
+    Rivers Cuomo - Application ID 2
     '''
 
-    applicants = ApplicationStatus.objects\
-                                  .filter(current_step__step=7)\
-                                  .filter(application__eds_sent=False)\
-                                  .distinct('application__email')
+    with patch.object(Command, 'send_email') as mock_send:
+        call_command('send_emails', eds_email=5, stdout=sys.stdout)
+        out, err = capsys.readouterr()
 
-    assert len(applicants) == 1
+    notification_message = 'Notified Rivers Cuomo - Application ID 1'
+    
+    applications = ['Rivers Cuomo - Application ID {}'.format(i) for i in (1, 2)]
+    applications_message = '\n'.join(applications)
 
-    application = applicants[0].application
-    applicant_name = ' '.join([application.first_name,
-                               application.last_name])
+    for message in (notification_message, applications_message):
+        assert message in out
 
-    assert applicant_name == 'Rivers Cuomo'
+    for applicant in ('Lana Del Rey', 'Robin Peckinold'):
+        assert applicant not in out
 
-    related_applications = Application.objects\
-                                      .filter(email=application.email)\
-                                      .filter(applicationstatus__current_step__step=7)\
-                                      .exclude(id=application.id)
+    updated_applications = Application.objects.filter(first_name='Rivers', 
+                                                      last_name='Cuomo')
 
-    assert len(related_applications) == 1
+    for application in updated_applications:
+        assert application.eds_sent == True
+        

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ psycopg2==2.6.2
 pytz==2016.7
 python-magic==0.4.12
 django-bootstrap-pagination==1.6.2
+pytest
+pytest-django


### PR DESCRIPTION
The current behavior selects chunks of applicants and sends emails to the subset on the correct step. It'd be easier to work with if it reliably emailed n applicants at a time. This PR implements that and adds a test.