### PR TITLE
Add start and end date to local_settings.py.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Set the environmental variables in [local_settings.py.example](https://github.co
 
   * ``SENTRY_DSN`` - This is a connection string for [Sentry](http://getsentry.com).
 
+Note that the example local settings sets `START_DATE` and `END_DATE` to now and two weeks from now, respectively, so you'll default to an "active" application period for local development. In production, these should correspond to the start and end dates of the current round's application period.
+
 Make a database and run migrations:
 
 ```bash

--- a/lots/local_settings.py.example
+++ b/lots/local_settings.py.example
@@ -1,3 +1,6 @@
+import datetime
+import pytz
+
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -58,3 +61,5 @@ DATABASES = {
 
 CURRENT_PILOT = "pilot_6_dev"
 CURRENT_CARTODB = "large_lots_2016_fall_expansion"
+START_DATE = datetime.datetime.now(pytz.timezone('America/Chicago'))
+END_DATE = START_DATE + datetime.timedelta(weeks=2)


### PR DESCRIPTION
START_DATE and END_DATE are used in the views but aren't in the example config. This PR adds them, with default values of today and two weeks from now, respectively, so you can get up and running, faster.