### PR TITLE
replaced Jeanne Chandler with The Large Lots Team & email

### DIFF
--- a/data/pilots_all/DATA_PREP.md
+++ b/data/pilots_all/DATA_PREP.md
@@ -6,7 +6,7 @@ The index page displays all the properties sold and currently under review. Gett
 
 First, you need a Postgress database with all city parcels, communities, and wards. Please see `DATA_PREP.md` at the root of the large-lots repo for information on creating a database with the necessary tables. Alternatively, you may create an `lis` database, given the instructions provided in [this repo](https://github.com/datamade/lis). Whatever the case, be sure that you assign the name of your database to the `PG_DB` variable in the `pilots_all/Makefile`.
 
-Then, request a list of all properties sold in previous pilots from the Department of Planning and Development (contact: Jeanne Chandler). Add that file to `pilots_all/raw/`. 
+Then, request a list of all properties sold in previous pilots from the Department of Planning and Development. Add that file to `pilots_all/raw/`. 
 
 Finally, run the Makefile:
 

--- a/templates/apply_confirm.html
+++ b/templates/apply_confirm.html
@@ -125,9 +125,9 @@
         <div class="col-sm-12">
             <p><strong>If you have any questions, please contact:</strong></p>
             <p>
-               Jeanne Chandler, Department of Planning and Development<br />
+               The Large Lots Team, Department of Planning and Development<br />
                Phone: (312) 744-0605<br />
-               Email: <a href='mailto:Jeanne.Chandler@cityofchicago.org'>Jeanne.Chandler@cityofchicago.org</a>
+               Email: <a href='mailto:info@largelots.org'>info@largelots.org</a>
             </p>
         </div>
     </div>

--- a/templates/apply_text_email.txt
+++ b/templates/apply_text_email.txt
@@ -20,6 +20,6 @@ Your contact info:
 
 If you have any questions, please contact:
 
-Jeanne Chandler, Department of Planning and Development
+The Large Lots Team, Department of Planning and Development
 Phone: (312) 744-0605
-Email: Jeanne.Chandler@cityofchicago.org
+Email: info@largelots.org

--- a/templates/city_council_denial_email.html
+++ b/templates/city_council_denial_email.html
@@ -25,14 +25,14 @@
                 <strong>Pin #: {{ lot.pin }}</strong>
             </p>
             <p>Unfortunately, your application has been denied because <strong>DPD is no longer proceeding with the sale of this lot through the Large Lot Program</strong>. You can learn more about our evaluation process by visiting our <a target='_blank' href='https://www.largelots.org/faq/'>frequently asked questions (FAQ) page</a>. Again, thank you for your application. You can stay informed on the Large Lots program through <a target='_blank' href='https://www.largelots.org/'>largelots.org</a> or <a target='_blank' href="https://www.cityofchicago.org/city/en/depts/dcd.html">cityofchicago.org/DPD</a>.</p>
-            <p>Feel free to contact me if you have any questions by email at  <a href="mailto:Jeanne.chandler@cityofchicago.org">Jeanne.chandler@cityofchicago.org</a>.</p>
+            <p>Feel free to contact me if you have any questions by email at  <a href="mailto:info@largelots.org">info@largelots.org</a>.</p>
 
             <p>Thank you for your application and we look forward to working with you in the future.</p>
         </div>
         <div class="row">
           <div class="col-md-12">
               <p>Sincerely,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/city_council_denial_email.txt
+++ b/templates/city_council_denial_email.txt
@@ -16,9 +16,9 @@ Again, thank you for your application. You can stay informed on the Large Lots p
 
 Feel free to contact me by email, if you have any questions.
 
-Jeanne Chandler, Department of Planning and Development
-Email: Jeanne.Chandler@cityofchicago.org
+The Large Lots Team, Department of Planning and Development
+Email: info@largelots.org
 
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/closing_invitation_email.html
+++ b/templates/closing_invitation_email.html
@@ -53,7 +53,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Best,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/closing_invitation_email.txt
+++ b/templates/closing_invitation_email.txt
@@ -37,4 +37,4 @@ Below are the items you will need to bring to the Closing:
 Looking forward to seeing you at the Closing!
 
 Sincerely,
-Jeanne Chandler
+The Large Lots Team

--- a/templates/closing_time_email.html
+++ b/templates/closing_time_email.html
@@ -65,7 +65,7 @@
       <div class="col-md-12">
           <p>Thanks again for your patience and participation. Looking forward to seeing all of you at Closing!</p>
           <p>Best,</p>
-          <p>Jeanne Chandler</p>
+          <p>The Large Lots Team</p>
       </div>
     </div>
 </div>

--- a/templates/closing_time_email.txt
+++ b/templates/closing_time_email.txt
@@ -43,4 +43,4 @@ More info can be found on the Large Lot program <a href="https://www.largelots.o
 Thanks again for your patience and participation. Looking forward to seeing all of you at Closing!
 
 Best,
-Jeanne Chandler
+The Large Lots Team

--- a/templates/deed_inquiry_email.html
+++ b/templates/deed_inquiry_email.html
@@ -32,7 +32,7 @@
         <div class="col-md-12">
             <p>Sorry for the inconvenience.<br />
             Sincerely,</p>
-            <p>Jeanne Chandler</p>
+            <p>The Large Lots Team</p>
         </div>
     </div>
 </div>

--- a/templates/deed_inquiry_email.txt
+++ b/templates/deed_inquiry_email.txt
@@ -21,4 +21,4 @@ Sorry for the inconvenience.
 
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/deed_upload_email.html
+++ b/templates/deed_upload_email.html
@@ -29,7 +29,7 @@
             {% endfor %}
 
             <p>Again, thank you for your application. We look forward to working with you in the future. You may stay informed on the Large Lots program through <a target='_blank' href='https://www.largelots.org/'>largelots.org</a> or <a target='_blank' href="https://www.cityofchicago.org/city/en/depts/dcd.html">cityofchicago.org/DPD</a>.</p>
-            <p>If you have any questions, feel free to contact Jeanne Chandler by email at <a href="mailto:Jeanne.chandler@cityofchicago.org">Jeanne.chandler@cityofchicago.org</a> or by phone at (312)744-0605.</p>
+            <p>If you have any questions, feel free to contact The Large Lots Team by email at <a href="mailto:info@largelots.org">info@largelots.org</a> or by phone at (312)744-0605.</p>
         </div>
     </div>
 </div>

--- a/templates/deed_upload_email.txt
+++ b/templates/deed_upload_email.txt
@@ -14,4 +14,4 @@ You successfully uploaded your property deed. The City will review your applicat
 
 Again, thank you for your application. We look forward to working with you in the future. You may stay informed on the Large Lots program through <a target='_blank' href='https://www.largelots.org/'>largelots.org</a> or <a target='_blank' href="https://www.cityofchicago.org/city/en/depts/dcd.html">cityofchicago.org/DPD</a>.
 
-If you have any questions, feel free to contact Jeanne Chandler by email at <a href="mailto:Jeanne.chandler@cityofchicago.org">Jeanne.chandler@cityofchicago.org</a> or by phone at (312)744-0605.
+If you have any questions, feel free to contact The Large Lots Team by email at <a href="mailto:info@largelots.org">info@largelots.org</a> or by phone at (312)744-0605.

--- a/templates/denial_garfield_email.html
+++ b/templates/denial_garfield_email.html
@@ -35,7 +35,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Sincerely,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/denial_garfield_email.txt
+++ b/templates/denial_garfield_email.txt
@@ -18,4 +18,4 @@ Thank you for your application.
         
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/denial_humboldt_email.html
+++ b/templates/denial_humboldt_email.html
@@ -35,7 +35,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Sincerely,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/denial_humboldt_email.txt
+++ b/templates/denial_humboldt_email.txt
@@ -18,4 +18,4 @@ Thank you for your application and we look forward to working with you in the fu
         
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/eds_denial_email.html
+++ b/templates/eds_denial_email.html
@@ -39,7 +39,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Best,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/eds_denial_email.txt
+++ b/templates/eds_denial_email.txt
@@ -26,4 +26,4 @@ We look forward to working with you in the future.
 
 Best,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/eds_email.html
+++ b/templates/eds_email.html
@@ -23,16 +23,16 @@
 
             <p>For individuals, please use <a href="https://eds.largelots.org/?tracking_id={{app.tracking_id}}">the following link to complete the EDS</a>.</p>
 
-            <p>For all applicants, please <a href="https://www.largelots.org/principal-profile-form/">download and complete the PPF</a>. Email your completed form to Jeanne.Chandler@Cityofchicago.org.</p>
+            <p>For all applicants, please <a href="https://www.largelots.org/principal-profile-form/">download and complete the PPF</a>. Email your completed form to info@largelots.org.</p>
 
-            <p><strong>Please note: both of these documents must be submitted by October 27, 2017 by 5:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact Jeanne Chandler or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>.</p>
+            <p><strong>Please note: both of these documents must be submitted by October 27, 2017 by 5:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>.</p>
 
             <p>For organizations and corporations, you must use <a href="https://webapps1.cityofchicago.org/EDSWeb/appmanager/OnlineEDS/desktop?_nfpb=true&_pageLabel=OnlineEDS_portal_page_26" target="_blank">the standard EDS form</a>.</p>
         </div>
         <div class="row">
           <div class="col-md-12">
               <p>Best,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/eds_email.txt
+++ b/templates/eds_email.txt
@@ -15,12 +15,12 @@ Congratulations! The City is moving forward with your Large Lot application. The
 
 For individuals, please use <a href="https://eds.largelots.org/?tracking_id={{app.tracking_id}}">the following link to complete the EDS</a>.
 
-For all applicants, please <a href="https://www.largelots.org/principal-profile-form/">download and complete the PPF</a>. Email your completed form to Jeanne.Chandler@Cityofchicago.org.
+For all applicants, please <a href="https://www.largelots.org/principal-profile-form/">download and complete the PPF</a>. Email your completed form to info@largelots.org.
 
-<strong>Please note: both of these documents must be submitted by October 27, 2017 by 5:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact Jeanne Chandler or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>. 
+<strong>Please note: both of these documents must be submitted by October 27, 2017 by 5:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>. 
 
 For organizations and corporations, you must use <a href="https://webapps1.cityofchicago.org/EDSWeb/appmanager/OnlineEDS/desktop?_nfpb=true&_pageLabel=OnlineEDS_portal_page_26" target="_blank">the standard EDS form</a>. 
         
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/emails/denial_email.html
+++ b/templates/emails/denial_email.html
@@ -25,7 +25,7 @@
             </p>
             <p>Unfortunately, your application has been denied because
             <strong>
-            <!-- Denial reasons for emails. Can be customized by Jeanne, if she so wishes. -->
+            <!-- Denial reasons for emails. Can be customized by DPD if they so wish. -->
             {% if review.denial_reason|slugify == DENIAL_REASONS.document|slugify %}
                 you did not include a valid deed for the property that you own.
             {% elif review.denial_reason|slugify == DENIAL_REASONS.deedoveruse|slugify %}
@@ -70,13 +70,13 @@
             </strong>
             You can learn more about our evaluation process by visiting our <a target='_blank' href='https://www.largelots.org/faq/'>frequently asked questions (FAQ) page</a>.</p>
             <p>Again, thank you for your application. You can stay informed on the Large Lots program through <a target='_blank' href='https://www.largelots.org/'>largelots.org</a> or <a target='_blank' href="https://www.cityofchicago.org/city/en/depts/dcd.html">cityofchicago.org/DPD</a>.</p>
-            <p>Feel free to contact me if you have any questions by email at  <a href="mailto:Jeanne.chandler@cityofchicago.org">Jeanne.chandler@cityofchicago.org</a>.</p>
+            <p>Feel free to contact me if you have any questions by email at  <a href="mailto:info@largelots.org">info@largelots.org</a>.</p>
         </div>
     </div>
     <div class="row">
         <div class="col-md-12">
             <p>Sincerely,</p>
-            <p>Jeanne Chandler</p>
+            <p>The Large Lots Team</p>
         </div>
     </div>
 </div>

--- a/templates/emails/denial_email.txt
+++ b/templates/emails/denial_email.txt
@@ -63,9 +63,9 @@ Again, thank you for your application. You can stay informed on the Large Lots p
 
 Feel free to contact me by email, if you have any questions.
 
-Jeanne Chandler, Department of Planning and Development
-Email: Jeanne.Chandler@cityofchicago.org
+The Large Lots Team, Department of Planning and Development
+Email: info@largelots.org
 
 Sincerely,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/emails/lotto_winner_email.html
+++ b/templates/emails/lotto_winner_email.html
@@ -22,8 +22,8 @@
         <p>Congratulations, and feel free to email me if you have any questions.</p>
         <p>Best,</p>
         <p>
-           Jeanne Chandler, Department of Planning and Development<br />
-           Jeanne.Chandler@cityofchicago.org
+           The Large Lots Team, Department of Planning and Development<br />
+           info@largelots.org
         </p>
     </div>
 </div>

--- a/templates/emails/lotto_winner_email.txt
+++ b/templates/emails/lotto_winner_email.txt
@@ -15,5 +15,5 @@ Congratulations, and feel free to email me if you have any questions.
 
 Best,
 
-Jeanne Chandler, Department of Planning and Development
-Jeanne.Chandler@cityofchicago.org
+The Large Lots Team, Department of Planning and Development
+info@largelots.org

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -54,9 +54,9 @@
     <div class="row">
       <div class="col-md-6">
       <p>
-        Jeanne Chandler<br />
+        The Large Lots Team<br />
         <i class="fa fa-phone" aria-hidden="true"></i> 312-744-0605<br />
-        <a href='mailto:Jeanne.Chandler@cityofchicago.org'>Jeanne.Chandler@cityofchicago.org</a>
+        <a href='mailto:info@largelots.org'>info@largelots.org</a>
       </p>
       <p>
         Kim Harrison<br />

--- a/templates/lottery_notification_afternoon.html
+++ b/templates/lottery_notification_afternoon.html
@@ -23,8 +23,8 @@
         <p>Feel free to email me if you have any questions.</p>
         <p>Best,</p>
         <p>
-           Jeanne Chandler, Department of Planning and Development<br />
-           Jeanne.Chandler@cityofchicago.org
+           The Large Lots Team, Department of Planning and Development<br />
+           info@largelots.org
         </p>
     </div>
 </div>

--- a/templates/lottery_notification_afternoon.txt
+++ b/templates/lottery_notification_afternoon.txt
@@ -17,6 +17,6 @@ Feel free to email me if you have any questions.
 
 Best,
 
-Jeanne Chandler, Department of Planning and Development
-Jeanne.Chandler@cityofchicago.org
+The Large Lots Team, Department of Planning and Development
+info@largelots.org
         

--- a/templates/lottery_notification_morning.html
+++ b/templates/lottery_notification_morning.html
@@ -23,8 +23,8 @@
         <p>Feel free to email me if you have any questions.</p>
         <p>Best,</p>
         <p>
-           Jeanne Chandler, Department of Planning and Development<br />
-           Jeanne.Chandler@cityofchicago.org
+           The Large Lots Team, Department of Planning and Development<br />
+           info@largelots.org
         </p>
     </div>
 </div>

--- a/templates/lottery_notification_morning.txt
+++ b/templates/lottery_notification_morning.txt
@@ -17,6 +17,6 @@ Feel free to email me if you have any questions.
 
 Best,
 
-Jeanne Chandler, Department of Planning and Development
-Jeanne.Chandler@cityofchicago.org
+The Large Lots Team, Department of Planning and Development
+info@largelots.org
         

--- a/templates/update_email.html
+++ b/templates/update_email.html
@@ -35,7 +35,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Best,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/update_email.txt
+++ b/templates/update_email.txt
@@ -16,4 +16,4 @@ Thank you for your patience through the review process.
 
 Best,
 
-Jeanne Chandler
+The Large Lots Team

--- a/templates/wintrust_email.html
+++ b/templates/wintrust_email.html
@@ -28,7 +28,7 @@
         <div class="row">
           <div class="col-md-12">
               <p>Best,</p>
-              <p>Jeanne Chandler</p>
+              <p>The Large Lots Team</p>
           </div>
         </div>
     </div>

--- a/templates/wintrust_email.txt
+++ b/templates/wintrust_email.txt
@@ -28,4 +28,4 @@ RSVP to Beverly Bank & Trust, Margaret O’Connell at 773-239-2265 ext: 2204261 
 
 Best,
 
-Jeanne Chandler
+The Large Lots Team


### PR DESCRIPTION
Jeanne Chandler, the head of the Large Lots program, is retiring from the City of Chicago on June 15, 2018. Jeanne we will miss you!

These changes replace her name and email address with 'The Large Lots Team' and info@largelots.org

