### PR TITLE
New email

### DIFF
--- a/lots_admin/forms.py
+++ b/lots_admin/forms.py
@@ -142,6 +142,9 @@ class CustomEmail(forms.Form):
                 widget=forms.HiddenInput(), 
                 initial='custom_form')
     step = forms.CharField(widget=forms.Select(choices=STEPS))
+    every_status = forms.BooleanField(
+                widget=forms.CheckboxInput(attrs={'style': 'margin-right: 8px'}),
+                required=False)
     selection = forms.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
     subject = forms.CharField(widget=forms.TextInput(attrs={'class':'form-control'}))
     email_text = forms.CharField(widget=forms.Textarea(attrs={'class': 'form-control','placeholder': 'Enter custom text for your email...', 'style': 'font-size: 18px'}))
@@ -152,5 +155,6 @@ class CustomEmail(forms.Form):
                      '-a {}'.format(self.user.id), 
                      custom_email=self.selection, 
                      steps=int(self.step),
+                     every_status=self.every_status,
                      base_context=json.dumps(self.base_context),
                      stdout=self.out)

--- a/lots_admin/management/commands/send_emails.py
+++ b/lots_admin/management/commands/send_emails.py
@@ -59,10 +59,6 @@ class Command(BaseCommand):
                             action='store_true',
                             help='Send email with link to complete EDS')
 
-        # parser.add_argument('--eds_correction_email',
-        #                     action='store_true',
-        #                     help='Send email with correct link to complete EDS. Used for a specific use case in late October.')
-
         parser.add_argument('--lotto_email',
                             action='store_true',
                             help='Send email with notification of lottery')
@@ -111,7 +107,7 @@ class Command(BaseCommand):
         if self.email_command == 'custom_email':
             self.operator = options['custom_email']
             self.step = options['steps']
-            self.every_status = options.get('every_status', '')
+            self.every_status = options['every_status']
 
         getattr(self, 'send_{}'.format(self.email_command))()
 
@@ -292,22 +288,6 @@ class Command(BaseCommand):
                 for app in apps:
                     app.eds_sent = True
                     app.save()
-
-    def send_eds_correction_email(self):
-        subject = 'Corrected links - PPF and EDS' 
-        for email, apps, statuses in self._select_applicants_on_step(7, every_status=True):
-            context = {'app': apps.first()}
-            context.update(self.base_context)
-
-            try:
-                self._send_email('eds_email_correction', subject, email, context)
-
-            except CannotSendEmailException as error:
-                for a in apps:
-                    self._write_to_stdout(a.id, error)
-
-            else:
-                self._log(apps.first(), statuses)
 
     def send_eds_final_email(self):
         subject = 'LargeLots application - Economic Disclosure Statement (EDS)' 

--- a/lots_admin/management/commands/send_emails.py
+++ b/lots_admin/management/commands/send_emails.py
@@ -179,7 +179,6 @@ class Command(BaseCommand):
                 yield email, apps, statuses
 
     _select_applicants_on_step = partialmethod(_select_applicants, '=')
-    _select_applicants_on_step_every_status = partialmethod(_select_applicants, '=', every_status=True)
     _select_applicants_not_on_step = partialmethod(_select_applicants, '!=')
     _select_applicants_on_steps_before = partialmethod(_select_applicants, '<')
     _select_applicants_on_steps_after = partialmethod(_select_applicants, '>')
@@ -406,12 +405,9 @@ class Command(BaseCommand):
         '''
         e.g., python manage.py send_emails --custom_email on_step --step 6 --every_status
         '''
-        if self.every_status and self.operator == 'on_step':
-            select_method = self._select_applicants_on_step_every_status
-        else:
-            select_method = getattr(self, '_select_applicants_{}'.format(self.operator))
+        select_method = getattr(self, '_select_applicants_{}'.format(self.operator))
 
-        for email, apps, statuses in select_method(self.step):
+        for email, apps, statuses in select_method(self.step, every_status=self.every_status):
             lots = [s.lot for s in statuses]
             context = {'app': apps.first(), 'lots': lots}
 

--- a/lots_admin/views.py
+++ b/lots_admin/views.py
@@ -1191,6 +1191,7 @@ class EmailHandler(LoginRequiredMixin, TemplateView):
         if self.request.POST.get('action') == 'custom_form':
             form.step = form.cleaned_data['step']
             form.selection = form.cleaned_data['selection']
+            form.every_status = form.cleaned_data['every_status']
             base_context['subject'] = form.cleaned_data['subject']
             base_context['email_text'] = form.cleaned_data['email_text']
 

--- a/templates/emails/custom_email.html
+++ b/templates/emails/custom_email.html
@@ -39,7 +39,7 @@
                 </table>
             {% endfor %}
 
-            <p>{{ email_text }}</p>
+            <p>{{ email_text | safe }}</p>
         </div>
         <div class="row">
           <div class="col-md-12">

--- a/templates/emails/eds_email.html
+++ b/templates/emails/eds_email.html
@@ -23,7 +23,7 @@
 
             <p>For individuals, please use <a href="https://eds.largelots.org/?tracking_id={{app.tracking_id}}">the following link to complete the EDS</a>.</p>
 
-            <p>For all applicants, please use <a href="https://www.largelots.org/principal-profile-form/{{app.tracking_id}}">the following link to complete the PPF</a>.</p>
+            <p>For all applicants, please use <a href="https://largelots.org/principal-profile-form/{{app.tracking_id}}">the following link to complete the PPF</a>.</p>
 
             <p><strong>Please note: both of these documents must be submitted on {{date}} by {{time}} or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>.</p>
 

--- a/templates/emails/eds_email.txt
+++ b/templates/emails/eds_email.txt
@@ -15,7 +15,7 @@ Congratulations! The City is moving forward with your Large Lot application. The
 
 For individuals, please use <a href="https://eds.largelots.org/?tracking_id={{app.tracking_id}}">the following link to complete the EDS</a>.
 
-For all applicants, please use <a href="https://www.largelots.org/principal-profile-form/{{app.tracking_id}}">the following link to complete the PPF</a>.
+For all applicants, please use <a href="https://largelots.org/principal-profile-form/{{app.tracking_id}}">the following link to complete the PPF</a>.
 
 <strong>Please note: both of these documents must be submitted on {{date}} by {{time}} or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or <a href="mailto:kim.harrison@cityofchicago.org">kim.harrison@cityofchicago.org</a>. 
 

--- a/templates/emails/eds_email_correction.html
+++ b/templates/emails/eds_email_correction.html
@@ -1,0 +1,40 @@
+{% load lots_filters %}
+
+<div style="font-family: Calibri, Arial, sans-serif; font-size: 14px;">
+    <div class="row">
+        <div class="col-md-12">
+            <a id='logo' href="http://largelots.org">
+            <img src='http://largelots.org/static/images/large_lots.png' alt='Large Lots' />
+            </a>
+            <p>{{ today|date:'F j, Y' }}</p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            {{ app.first_name}} {{ app.last_name }}<br />
+            {{ app.owned_address }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <p>Dear {{ app.first_name }},</p>
+
+            <p>We are aware of the issues with the links for submitting your EDS and PPF. Please see the corrected links below. If you successfully submitted the EDS you only need to complete the PPF.</p>
+
+            <p>For all applicants, please use <a href="https://largelots.org/principal-profile-form/{{app.tracking_id}}">this UPDATED link to complete the PPF</a>.</p>
+
+            <p>For individuals, who encountered errors in submitting an EDS, please use <a href="https://eds.largelots.org/reauthenticate?tracking_id={{app.tracking_id}}">the following link to reenter the EDS form</a>.</p>
+
+            <p>For organizations and corporations, you must use <a href="https://webapps1.cityofchicago.org/EDSWeb/appmanager/OnlineEDS/desktop?_nfpb=true&_pageLabel=OnlineEDS_portal_page_26" target="_blank">the standard EDS form</a>.</p>
+
+            <p><strong>Again, both of these documents must be submitted on November 9, 2018 by 04:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or kim.harrison@cityofchicago.org.</p>
+
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+              <p>Best,</p>
+              <p>The Large Lots Team</p>
+          </div>
+        </div>
+    </div>
+</div>

--- a/templates/emails/eds_email_correction.txt
+++ b/templates/emails/eds_email_correction.txt
@@ -1,0 +1,26 @@
+{% load lots_filters %}
+
+
+** $1 LARGE LOTS
+------------------------------------------------------------
+{{ today|date:'F j, Y' }}
+
+{{ app.first_name}} {{ app.last_name }}
+{{ app.owned_address }}
+
+
+Dear {{ app.first_name}},
+
+We are aware of the issues with the links for submitting your EDS and PPF. Please see the corrected links below. If you successfully submitted the EDS you only need to complete the PPF.
+
+For all applicants, please use <a href="https://largelots.org/principal-profile-form/{{app.tracking_id}}">this UPDATED link to complete the PPF</a>.
+
+For individuals, who encountered errors in submitting an EDS, please use <a href="https://eds.largelots.org/reauthenticate?tracking_id={{app.tracking_id}}">the following link to reenter the EDS form</a>.
+
+For organizations and corporations, you must use <a href="https://webapps1.cityofchicago.org/EDSWeb/appmanager/OnlineEDS/desktop?_nfpb=true&_pageLabel=OnlineEDS_portal_page_26" target="_blank">the standard EDS form</a>.
+
+<strong>Again, both of these documents must be submitted on November 9, 2018 by 04:00 PM or you will not be eligible to purchase property through the Large Lot Program.</strong> If you need assistance completing the EDS or PPF, please contact The Large Lots Team or Kim Harrison at 312-744-0605 or kim.harrison@cityofchicago.org.
+        
+Sincerely,
+
+The Large Lots Team

--- a/templates/send_emails.html
+++ b/templates/send_emails.html
@@ -165,7 +165,7 @@
             {% endfor %}
         </div>
     </p>
-    <p><strong>Step 3. OPTIONAL.</strong><br>{{ custom_form.every_status }} If you selected "applicants on this step," check here if you ONLY want to send emails to applicants who have all applications on this step.</p>
+    <p><strong>Step 3. OPTIONAL.</strong><br>{{ custom_form.every_status }} If you selected "applicants on this step," check here if you ONLY want to send emails to applicants who have all non-denied applications on this step. For example, EDS and PPF emails are only sent to applicants who have all non-denied applications on Step 7. Select this option and "Step 7" (above) to send a second email to this pool.</p>
     <p>
         <strong>Step 4.</strong> Give your email a subject line 
         {% if custom_form.subject.errors %}

--- a/templates/send_emails.html
+++ b/templates/send_emails.html
@@ -225,6 +225,19 @@
 
                 return true;
             });
+
+            $('#id_selection_0').on('click', function() {
+                $("#id_every_status").attr("disabled", false);
+            });
+            $('#id_selection_1').on('click', function() {
+                $("#id_every_status").attr("disabled", true);
+            });
+            $('#id_selection_2').on('click', function() {
+                $("#id_every_status").attr("disabled", true);
+            });
+            $('#id_selection_3').on('click', function() {
+                $("#id_every_status").attr("disabled", true);
+            });
         } );
     </script>
 {% endblock %}

--- a/templates/send_emails.html
+++ b/templates/send_emails.html
@@ -165,8 +165,9 @@
             {% endfor %}
         </div>
     </p>
+    <p><strong>Step 3. OPTIONAL.</strong><br>{{ custom_form.every_status }} If you selected "applicants on this step," check here if you ONLY want to send emails to applicants who have all applications on this step.</p>
     <p>
-        <strong>Step 3.</strong> Give your email a subject line 
+        <strong>Step 4.</strong> Give your email a subject line 
         {% if custom_form.subject.errors %}
         <div class='has-error'>
         {% else %}
@@ -178,7 +179,7 @@
             {% endfor %}
         </div>
     </p>
-    <p><strong>Step 4.</strong> Enter the body of your custom email. <strong>Note!</strong> The text above and below the input box show an example Large Lots header and closing statement: your email will contain actual applicant info.</p>
+    <p><strong>Step 5.</strong> Enter the body of your custom email. <strong>Note!</strong> The text above and below the input box show an example Large Lots header and closing statement: your email will contain actual applicant info.</p>
     <hr>
     <em><p>Dear Ms. Bordoni,</p>
     <p>This email concerns your application for the following lots:</p>

--- a/tests/lots_admin/test_emails.py
+++ b/tests/lots_admin/test_emails.py
@@ -119,7 +119,7 @@ class TestCustomEmail:
     @pytest.mark.parametrize('custom,step,q_filter', parameters)
     @pytest.mark.django_db
     def test_command(self, email_db_setup, caplog, custom, step, q_filter):
-        base_context = {'subject': 'test email'}
+        base_context = {'subject': 'test email', 'email_text': 'test text'}
 
         with caplog.at_level(logging.INFO):
             with patch.object(Command, '_send_email') as mock_send:
@@ -136,6 +136,7 @@ class TestCustomEmail:
             response = auth_client.post(url, {
                     'action': 'custom_form',
                     'step': step,
+                    'every_status': False,
                     'selection': custom,
                     'subject': 'an email subject line',
                     'text': 'a custom email for you' 


### PR DESCRIPTION
This PR makes a few modifications to the email interface:

* It enables users to include variables in the custom_email form, e.g., app.tracking_id – primarily for DataMade use
* It adds a `--every_status` flag, allowing users to specify if they wish to send emails to applicants who have all non-denied applications on particular step

***

After deploying, DataMade will use the new interface to send emails to applicants with all non-denied applications on Step 7. The email will provide up-to-date links for the PPF and EDS. [Email text in this commit.](https://github.com/datamade/large-lots/pull/387/commits/101fd50ea153daa75ebfa59b579163ba165e31da#diff-261162400be4ccbc81ce98bf73ca4ec8R22)