### PR TITLE
Do not require home state

### DIFF
--- a/lots_client/forms.py
+++ b/lots_client/forms.py
@@ -230,6 +230,7 @@ class PrincipalProfileForm(forms.Form):
     home_address_city = forms.CharField()
     home_address_state = forms.ChoiceField(
         widget=forms.Select(attrs={'class': 'form-control'}),
+        required=False,
     )
     home_address_zip_code = forms.CharField()
     date_of_birth = forms.DateField(widget=forms.SelectDateWidget(


### PR DESCRIPTION
This PR changes the validation requirements for the `home_address_state` in the PPF. 

The form pre-populates this field for individual applicants - however, it seems to expect that the state map onto those in [`STATES`](https://github.com/datamade/large-lots/blob/master/lots_client/forms.py#L14) from us.states. 

The applicant address data varies greatly, unfortunately. I ran `select distinct(state) from lots_admin_address;` and got the following:

```
ILINOIS
 ILL
 60628
 ILLONOIS
 ILLIONIS
 TX
 ILLINOIS (IL)
 NY
 UTAH
 ILLINIOS
 ILL.
 NM
 IN
 ILLINOIS
 FL
 GEORGIA
 ILLLINOIS
 IL. 60181
 GA
 MN
 MD
 I
 ARIZONA
 TEXAS
 IL
 TN
 STATE
 CO
 VA
 IL.
 INDIANA
 COOK
 IL - ILLINOIS
```

As such, the formset does not validate, but raises `[{'home_address_state': ['This field is required.']}]`

As a quick fix, I added `required=False` to the home_address_state field, since it seems inconsequential to the [PPF data export](https://github.com/datamade/large-lots/blob/master/lots_admin/views.py#L362). 

Moving forward, we might want to give users a dropdown for selecting their state on the application. 